### PR TITLE
chore: Change repo URL to the new location

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -2,7 +2,7 @@ style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
-  repository_url: https://github.com/awslabs/aws-lambda-powertools-dotnet
+  repository_url: https://github.com/aws-powertools/lambda-dotnet
 options:
   commits:
     filters:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     id: logs
     attributes:
       label: Debugging logs
-      description: If available, please share [debugging logs](https://awslabs.github.io/aws-lambda-powertools-dotnet/#debug-mode)
+      description: If available, please share [debugging logs](https://docs.powertools.aws.dev/lambda-dotnet/#debug-mode)
       render: csharp
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thank you for submitting a bug report. Please add as much information as possible to help us reproduce, and remove any potential sensitive data.
 
-        Please become familiar with [our definition of bug](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/MAINTAINERS.md#is-that-a-bug).
+        Please become familiar with [our definition of bug](https://github.com/aws-powertools/lambda-dotnet/blob/develop/MAINTAINERS.md#is-that-a-bug).
   - type: textarea
     id: expected_behaviour
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/awslabs/aws-lambda-powertools-dotnet/discussions/new
+    url: https://github.com/aws-powertools/lambda-dotnet/discussions/new
     about: Ask a general question about Lambda Powertools

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
+        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://docs.powertools.aws.dev/lambda-dotnet/tenets)
           required: true
         - label: Should this be considered in other Powertools for AWS Lambda languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
           required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This feature request meets [Lambda Powertools Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
+        - label: This feature request meets [Lambda Powertools Tenets](https://docs.powertools.aws.dev/lambda-dotnet/tenets)
           required: true
         - label: Should this be considered in other Lambda Powertools languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
           required: false

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -60,7 +60,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This request meets [Lambda Powertools Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/latest/#tenets)
+        - label: This request meets [Lambda Powertools Tenets](https://docs.powertools.aws.dev/lambda-dotnet/latest/#tenets)
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -60,7 +60,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This request meets [Powertools for AWS Lambda (.NET) Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/latest/#tenets)
+        - label: This request meets [Powertools for AWS Lambda (.NET) Tenets](https://docs.powertools.aws.dev/lambda-dotnet/latest/#tenets)
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -79,7 +79,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This feature request meets [Lambda Powertools Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets/)
+        - label: This feature request meets [Lambda Powertools Tenets](https://docs.powertools.aws.dev/lambda-dotnet/tenets/)
           required: true
         - label: Should this be considered in other Lambda Powertools languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
           required: false

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -79,7 +79,7 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets/)
+        - label: This feature request meets [Powertools for AWS Lambda (.NET) Tenets](https://docs.powertools.aws.dev/lambda-dotnet/tenets/)
           required: true
         - label: Should this be considered in other Powertools for AWS Lambda (.NET) languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python), [Java](https://github.com/awslabs/aws-lambda-powertools-java/), and [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
           required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Please leave checklist items unchecked if they do not apply to your change.
 * [ ] I have performed a self-review of this change
 * [ ] Changes have been tested
 * [ ] Changes are documented
-* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)
+* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/lambda-dotnet/blob/develop/.github/semantic.yml)
 
 
 <details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Issue number:
 
 Please leave checklist items unchecked if they do not apply to your change.
 
-* [ ] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
+* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda-dotnet/tenets)
 * [ ] I have performed a self-review of this change
 * [ ] Changes have been tested
 * [ ] Changes are documented

--- a/.github/workflows/dispatch_analytics.yml
+++ b/.github/workflows/dispatch_analytics.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   dispatch_token:
-    if: github.repository == 'awslabs/aws-lambda-powertools-dotnet'
+    if: github.repository == 'aws-powertools/lambda-dotnet'
     concurrency:
       group: analytics
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable_export_pr_details.yml
+++ b/.github/workflows/reusable_export_pr_details.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   export_pr_details:
     # see https://github.com/awslabs/aws-lambda-powertools-python/issues/1349
-    if: inputs.workflow_origin == 'awslabs/aws-lambda-powertools-dotnet'
+    if: inputs.workflow_origin == 'aws-powertools/lambda-dotnet'
     runs-on: ubuntu-latest
     env:
       FILENAME: pr.txt

--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -2,7 +2,7 @@ name: Reusable publish documentation
 
 env:
   BRANCH: develop
-  ORIGIN: awslabs/aws-lambda-powertools-dotnet
+  ORIGIN: aws-powertools/lambda-dotnet
 
 on:
   workflow_call:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,19 +23,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Pull Requests
 
-* Merge pull request [#268](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/268) from amirkaws/amirkaws-release-version-1.3.0
-* Merge pull request [#167](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/167) from amirkaws/amirkaws-feature-parameters
-* Merge pull request [#1](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/1) from sliedig/amirkaws-feature-parameters
-* Merge pull request [#264](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/264) from awslabs/chore(ci)-skip-analytics-on-forks
-* Merge pull request [#262](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/262) from awslabs/chorebump-version-1.2.0-release
+* Merge pull request [#268](https://github.com/aws-powertools/lambda-dotnet/issues/268) from amirkaws/amirkaws-release-version-1.3.0
+* Merge pull request [#167](https://github.com/aws-powertools/lambda-dotnet/issues/167) from amirkaws/amirkaws-feature-parameters
+* Merge pull request [#1](https://github.com/aws-powertools/lambda-dotnet/issues/1) from sliedig/amirkaws-feature-parameters
+* Merge pull request [#264](https://github.com/aws-powertools/lambda-dotnet/issues/264) from awslabs/chore(ci)-skip-analytics-on-forks
+* Merge pull request [#262](https://github.com/aws-powertools/lambda-dotnet/issues/262) from awslabs/chorebump-version-1.2.0-release
 
 
 <a name="1.2.0"></a>
 ## [1.2.0] - 2023-05-05
 ## Pull Requests
 
-* Merge pull request [#258](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/258) from amirkaws/amirkaws-release-version-1.2.0
-* Merge pull request [#226](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/226) from hjgraca/feat_support_high_resolution_metrics
+* Merge pull request [#258](https://github.com/aws-powertools/lambda-dotnet/issues/258) from amirkaws/amirkaws-release-version-1.2.0
+* Merge pull request [#226](https://github.com/aws-powertools/lambda-dotnet/issues/226) from hjgraca/feat_support_high_resolution_metrics
 
 
 <a name="1.1.0"></a>
@@ -48,24 +48,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Pull Requests
 
-* Merge pull request [#255](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/255) from awslabs/fix-remove-real-env-tests
-* Merge pull request [#253](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/253) from amirkaws/amirkaws-release-v1.1.0
-* Merge pull request [#246](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/246) from hjgraca/feat_set-execution-context
-* Merge pull request [#251](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/251) from leandrodamascena/issues-templates/python
-* Merge pull request [#241](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/241) from awslabs/update-changelog-4691350388
-* Merge pull request [#237](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/237) from hjgraca/changelog-update-pipeline
-* Merge pull request [#235](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/235) from amirkaws/amirkaws-update-examples-nuget-references-release-v1.0.1
+* Merge pull request [#255](https://github.com/aws-powertools/lambda-dotnet/issues/255) from awslabs/fix-remove-real-env-tests
+* Merge pull request [#253](https://github.com/aws-powertools/lambda-dotnet/issues/253) from amirkaws/amirkaws-release-v1.1.0
+* Merge pull request [#246](https://github.com/aws-powertools/lambda-dotnet/issues/246) from hjgraca/feat_set-execution-context
+* Merge pull request [#251](https://github.com/aws-powertools/lambda-dotnet/issues/251) from leandrodamascena/issues-templates/python
+* Merge pull request [#241](https://github.com/aws-powertools/lambda-dotnet/issues/241) from awslabs/update-changelog-4691350388
+* Merge pull request [#237](https://github.com/aws-powertools/lambda-dotnet/issues/237) from hjgraca/changelog-update-pipeline
+* Merge pull request [#235](https://github.com/aws-powertools/lambda-dotnet/issues/235) from amirkaws/amirkaws-update-examples-nuget-references-release-v1.0.1
 
 
 <a name="v1.0.1"></a>
 ## [v1.0.1] - 2023-04-06
 ## Pull Requests
 
-* Merge pull request [#232](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/232) from amirkaws/amirkaws-release-v1.0.1
-* Merge pull request [#227](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/227) from hjgraca/chore_fix_changelog_build
-* Merge pull request [#225](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/225) from srcsakthivel/develop
-* Merge pull request [#223](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/223) from hjgraca/fix_tracing_on_exception_thrown
-* Merge pull request [#218](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/218) from amirkaws/amirkaws-update-examples-nuget-references-release
+* Merge pull request [#232](https://github.com/aws-powertools/lambda-dotnet/issues/232) from amirkaws/amirkaws-release-v1.0.1
+* Merge pull request [#227](https://github.com/aws-powertools/lambda-dotnet/issues/227) from hjgraca/chore_fix_changelog_build
+* Merge pull request [#225](https://github.com/aws-powertools/lambda-dotnet/issues/225) from srcsakthivel/develop
+* Merge pull request [#223](https://github.com/aws-powertools/lambda-dotnet/issues/223) from hjgraca/fix_tracing_on_exception_thrown
+* Merge pull request [#218](https://github.com/aws-powertools/lambda-dotnet/issues/218) from amirkaws/amirkaws-update-examples-nuget-references-release
 
 
 <a name="v1.0.0"></a>
@@ -80,7 +80,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Maintenance
 
-* **ci:** api docs build update ([#188](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/188))
+* **ci:** api docs build update ([#188](https://github.com/aws-powertools/lambda-dotnet/issues/188))
 * **ci:** changing trigger to run manually
 * **ci:** updated api docs implementation
 * **ci:** updated bug report template
@@ -89,21 +89,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Pull Requests
 
-* Merge pull request [#215](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/215) from amirkaws/amirkaws-release-v1.0.0
-* Merge pull request [#208](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/208) from amirkaws/amirkaws-cold-start-capture-warning-bug-fix
-* Merge pull request [#210](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/210) from awslabs/powertools-definition-update
-* Merge pull request [#209](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/209) from amirkaws/amirkaws-metrics-timestamp-fix
-* Merge pull request [#199](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/199) from awslabs/sliedig-ci-reviewers
-* Merge pull request [#193](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/193) from hjgraca/maintenance-new-issue-template
-* Merge pull request [#202](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/202) from hjgraca/fix-test-json-escaping
-* Merge pull request [#195](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/195) from hjgraca/update-dotnet-sdk-6.0.405
-* Merge pull request [#194](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/194) from hjgraca/patch-1
-* Merge pull request [#192](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/192) from hjgraca/fix-incorrect-crefs
-* Merge pull request [#189](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/189) from sliedig/develop
-* Merge pull request [#185](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/185) from amirkaws/amirkaws-update-examples-nuget-references
-* Merge pull request [#183](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/183) from awslabs/develop
-* Merge pull request [#150](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/150) from awslabs/develop
-* Merge pull request [#140](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/140) from awslabs/develop
+* Merge pull request [#215](https://github.com/aws-powertools/lambda-dotnet/issues/215) from amirkaws/amirkaws-release-v1.0.0
+* Merge pull request [#208](https://github.com/aws-powertools/lambda-dotnet/issues/208) from amirkaws/amirkaws-cold-start-capture-warning-bug-fix
+* Merge pull request [#210](https://github.com/aws-powertools/lambda-dotnet/issues/210) from awslabs/powertools-definition-update
+* Merge pull request [#209](https://github.com/aws-powertools/lambda-dotnet/issues/209) from amirkaws/amirkaws-metrics-timestamp-fix
+* Merge pull request [#199](https://github.com/aws-powertools/lambda-dotnet/issues/199) from awslabs/sliedig-ci-reviewers
+* Merge pull request [#193](https://github.com/aws-powertools/lambda-dotnet/issues/193) from hjgraca/maintenance-new-issue-template
+* Merge pull request [#202](https://github.com/aws-powertools/lambda-dotnet/issues/202) from hjgraca/fix-test-json-escaping
+* Merge pull request [#195](https://github.com/aws-powertools/lambda-dotnet/issues/195) from hjgraca/update-dotnet-sdk-6.0.405
+* Merge pull request [#194](https://github.com/aws-powertools/lambda-dotnet/issues/194) from hjgraca/patch-1
+* Merge pull request [#192](https://github.com/aws-powertools/lambda-dotnet/issues/192) from hjgraca/fix-incorrect-crefs
+* Merge pull request [#189](https://github.com/aws-powertools/lambda-dotnet/issues/189) from sliedig/develop
+* Merge pull request [#185](https://github.com/aws-powertools/lambda-dotnet/issues/185) from amirkaws/amirkaws-update-examples-nuget-references
+* Merge pull request [#183](https://github.com/aws-powertools/lambda-dotnet/issues/183) from awslabs/develop
+* Merge pull request [#150](https://github.com/aws-powertools/lambda-dotnet/issues/150) from awslabs/develop
+* Merge pull request [#140](https://github.com/aws-powertools/lambda-dotnet/issues/140) from awslabs/develop
 
 
 <a name="v0.0.2-preview"></a>
@@ -119,30 +119,30 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## Features
 
-* **ci:** codeql static code analysis ([#148](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/148))
+* **ci:** codeql static code analysis ([#148](https://github.com/aws-powertools/lambda-dotnet/issues/148))
 
 ## Maintenance
 
 * updated setup-dotnet[@v1](https://github.com/v1) to [@v3](https://github.com/v3)
-* updated packages ([#172](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/172))
+* updated packages ([#172](https://github.com/aws-powertools/lambda-dotnet/issues/172))
 * **ci:** bumped version
 * **ci:** minor updates, licensing
 * **deps:** bump gitpython from 3.1.29 to 3.1.30
-* **docs:** updated documentation ([#175](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/175))
+* **docs:** updated documentation ([#175](https://github.com/aws-powertools/lambda-dotnet/issues/175))
 * **docs:** add discord invitation link
 
 ## Pull Requests
 
-* Merge pull request [#182](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/182) from sliedig/develop
-* Merge pull request [#181](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/181) from awslabs/dependabot/pip/gitpython-3.1.30
-* Merge pull request [#179](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/179) from sliedig/sliedig-ci
-* Merge pull request [#174](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/174) from sliedig/sliedig-ci
-* Merge pull request [#173](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/173) from sliedig/sliedig-samples
-* Merge pull request [#157](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/157) from kenfdev/fix-readme-title-typo
-* Merge pull request [#170](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/170) from nCubed/develop
-* Merge pull request [#152](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/152) from amirkaws/amirkaws-custom-exception-json-converter
-* Merge pull request [#155](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/155) from sthuber90/add-discord-link-154
-* Merge pull request [#147](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/147) from amirkaws/amirkaws-fix-doc-links
+* Merge pull request [#182](https://github.com/aws-powertools/lambda-dotnet/issues/182) from sliedig/develop
+* Merge pull request [#181](https://github.com/aws-powertools/lambda-dotnet/issues/181) from awslabs/dependabot/pip/gitpython-3.1.30
+* Merge pull request [#179](https://github.com/aws-powertools/lambda-dotnet/issues/179) from sliedig/sliedig-ci
+* Merge pull request [#174](https://github.com/aws-powertools/lambda-dotnet/issues/174) from sliedig/sliedig-ci
+* Merge pull request [#173](https://github.com/aws-powertools/lambda-dotnet/issues/173) from sliedig/sliedig-samples
+* Merge pull request [#157](https://github.com/aws-powertools/lambda-dotnet/issues/157) from kenfdev/fix-readme-title-typo
+* Merge pull request [#170](https://github.com/aws-powertools/lambda-dotnet/issues/170) from nCubed/develop
+* Merge pull request [#152](https://github.com/aws-powertools/lambda-dotnet/issues/152) from amirkaws/amirkaws-custom-exception-json-converter
+* Merge pull request [#155](https://github.com/aws-powertools/lambda-dotnet/issues/155) from sthuber90/add-discord-link-154
+* Merge pull request [#147](https://github.com/aws-powertools/lambda-dotnet/issues/147) from amirkaws/amirkaws-fix-doc-links
 
 
 <a name="v0.0.1-preview.1"></a>
@@ -156,7 +156,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * skip duplicate nuget packages publish
 * added missing runtimes
 * updated Logging template description
-* updated documentation and doc generation ([#96](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/96))
+* updated documentation and doc generation ([#96](https://github.com/aws-powertools/lambda-dotnet/issues/96))
 * removed optional doc file paths
 * explicitly adding doc files for build configurations
 * resolving dependecy alert CVE-2020-8116
@@ -178,27 +178,27 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * fixed nav for roadmap
 * updated link to feature request; added roadmap
-* library readme updates and minor updates  ([#117](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/117))
-* spell check with US-English dictionary ([#115](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/115))
-* docs review ([#112](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/112))
-* Reviewing documentation ([#68](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/68))
-* adding auto-generated API Reference to docs ([#87](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/87))
-* alternative brew installation ([#86](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/86))
-* homebrew installation ([#85](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/85))
-* merging api generation tasks ([#84](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/84))
-* fixing docfx path ([#83](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/83))
-* fix docfx path ([#82](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/82))
-* fix api docs generator installation ([#81](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/81))
-* update github actions to publish api docs ([#80](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/80))
-* API docs generation ([#79](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/79))
+* library readme updates and minor updates  ([#117](https://github.com/aws-powertools/lambda-dotnet/issues/117))
+* spell check with US-English dictionary ([#115](https://github.com/aws-powertools/lambda-dotnet/issues/115))
+* docs review ([#112](https://github.com/aws-powertools/lambda-dotnet/issues/112))
+* Reviewing documentation ([#68](https://github.com/aws-powertools/lambda-dotnet/issues/68))
+* adding auto-generated API Reference to docs ([#87](https://github.com/aws-powertools/lambda-dotnet/issues/87))
+* alternative brew installation ([#86](https://github.com/aws-powertools/lambda-dotnet/issues/86))
+* homebrew installation ([#85](https://github.com/aws-powertools/lambda-dotnet/issues/85))
+* merging api generation tasks ([#84](https://github.com/aws-powertools/lambda-dotnet/issues/84))
+* fixing docfx path ([#83](https://github.com/aws-powertools/lambda-dotnet/issues/83))
+* fix docfx path ([#82](https://github.com/aws-powertools/lambda-dotnet/issues/82))
+* fix api docs generator installation ([#81](https://github.com/aws-powertools/lambda-dotnet/issues/81))
+* update github actions to publish api docs ([#80](https://github.com/aws-powertools/lambda-dotnet/issues/80))
+* API docs generation ([#79](https://github.com/aws-powertools/lambda-dotnet/issues/79))
 
 ## Features
 
 * added security.md
 * updated record_pr action
-* PR Labeler GitHub actions ([#119](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/119))
-* Logger output case attributes docs and unit testing ([#100](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/100))
-* add extra fields to the logger methods ([#98](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/98))
+* PR Labeler GitHub actions ([#119](https://github.com/aws-powertools/lambda-dotnet/issues/119))
+* Logger output case attributes docs and unit testing ([#100](https://github.com/aws-powertools/lambda-dotnet/issues/100))
+* add extra fields to the logger methods ([#98](https://github.com/aws-powertools/lambda-dotnet/issues/98))
 * updated examples to include managed runtime configuration as well as docker. Made updates to Tracing implementation
 * added Tracing example
 * added init Metrics sample
@@ -226,7 +226,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * added customer 404 page
 * removing unecessary buildtools
 * update pr template
-* updating type documentation and file headers ([#56](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/56))
+* updating type documentation and file headers ([#56](https://github.com/aws-powertools/lambda-dotnet/issues/56))
 * moved solution file into libraries. Need a separate solution for examples
 * added docs
 * added gitignore and updated licence
@@ -238,8 +238,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * removed unnecessary pr labeling
 * updated PR labeling path
 * updated list of assignees
-* updated docker builds to use Amazon.Lambda.Tools ([#118](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/118))
-* bumped .net version in global to 6.0.301 ([#120](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/120))
+* updated docker builds to use Amazon.Lambda.Tools ([#118](https://github.com/aws-powertools/lambda-dotnet/issues/118))
+* bumped .net version in global to 6.0.301 ([#120](https://github.com/aws-powertools/lambda-dotnet/issues/120))
 * bumped .net version in global to 6.0.301
 * adding missed copyright info
 * added copyright to examples
@@ -248,7 +248,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **ci:** add on_merge_pr workflow to notify releases
 * **ci:** lockdown untrusted workflows to sha
 * **ci:** add missing scripts
-* **ci:** updated bug report template ([#144](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/144))
+* **ci:** updated bug report template ([#144](https://github.com/aws-powertools/lambda-dotnet/issues/144))
 * **ci:** add workflow to detect missing related issue
 * **ci:** enable concurrency group for docs workflow
 * **ci:** upudated wording in PR template checklist
@@ -269,70 +269,70 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** bump underscore from 1.12.0 to 1.13.1 in /docs
 * **deps:** bump url-parse from 1.4.7 to 1.5.1 in /docs
 * **deps:** bump prismjs from 1.20.0 to 1.21.0 in /docs
-* **deps:** updates sample deps ([#142](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/142))
-* **deps:** bump mkdocs from 1.2.2 to 1.2.3 ([#29](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/29))
+* **deps:** updates sample deps ([#142](https://github.com/aws-powertools/lambda-dotnet/issues/142))
+* **deps:** bump mkdocs from 1.2.2 to 1.2.3 ([#29](https://github.com/aws-powertools/lambda-dotnet/issues/29))
 * **governance:** render debug logs with csharp syntax
 * **governance:** typo in pending release label name
 
 ## Pull Requests
 
-* Merge pull request [#139](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/139) from awslabs/amirkaws-resolve-conflicts-2
-* Merge pull request [#135](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/135) from awslabs/amirkaws-update-versions
-* Merge pull request [#134](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/134) from heitorlessa/chore/lockdown-gh-pages-workflow
-* Merge pull request [#132](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/132) from heitorlessa/chore/github-concurrency-docs
-* Merge pull request [#130](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/130) from heitorlessa/chore/enforce-github-actions-sha
-* Merge pull request [#128](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/128) from sliedig/sliedig-ci
-* Merge pull request [#127](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/127) from sliedig/sliedig-ci
-* Merge pull request [#126](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/126) from sliedig/develop
-* Merge pull request [#123](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/123) from sliedig/develop
-* Merge pull request [#1](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/1) from sliedig/sliedig/develop
-* Merge pull request [#121](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/121) from awslabs/amirkaws-update-versions
-* Merge pull request [#116](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/116) from awslabs/amirkaws/add-di-support-for-logging
-* Merge pull request [#113](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/113) from awslabs/amirkaws/update-doc-1
-* Merge pull request [#111](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/111) from awslabs/amirkaws/add-env-vars-docs
-* Merge pull request [#102](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/102) from sliedig/sliedig/examples
-* Merge pull request [#103](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/103) from awslabs/amirkaws/fix-example-issues
-* Merge pull request [#97](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/97) from sliedig/sliedig/examples
-* Merge pull request [#95](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/95) from awslabs/pr/91
-* Merge pull request [#90](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/90) from sliedig/develop
-* Merge pull request [#89](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/89) from awslabs/api-docs-template
-* Merge pull request [#74](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/74) from awslabs/amirkaws/disable-tracing-outside-lambda-env
-* Merge pull request [#66](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/66) from sliedig/develop
-* Merge pull request [#59](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/59) from sliedig/develop
-* Merge pull request [#58](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/58) from sliedig/sliedig/nuget
-* Merge pull request [#32](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/32) from awslabs/amirkaws/metrics-1
-* Merge pull request [#31](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/31) from t1agob/develop
-* Merge pull request [#2](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/2) from awslabs/develop
-* Merge pull request [#25](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/25) from t1agob/develop
-* Merge pull request [#1](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/1) from t1agob/sourcegenerators
-* Merge pull request [#24](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/24) from sliedig/develop
-* Merge pull request [#23](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/23) from sliedig/develop
-* Merge pull request [#22](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/22) from sliedig/develop
-* Merge pull request [#21](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/21) from t1agob/develop
-* Merge pull request [#19](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/19) from awslabs/dependabot/npm_and_yarn/docs/url-parse-1.5.1
-* Merge pull request [#18](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/18) from awslabs/dependabot/npm_and_yarn/docs/hosted-git-info-2.8.9
-* Merge pull request [#17](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/17) from awslabs/dependabot/npm_and_yarn/docs/ua-parser-js-0.7.28
-* Merge pull request [#16](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/16) from awslabs/dependabot/npm_and_yarn/docs/underscore-1.13.1
-* Merge pull request [#15](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/15) from awslabs/dependabot/npm_and_yarn/docs/ssri-6.0.2
-* Merge pull request [#14](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/14) from awslabs/dependabot/npm_and_yarn/docs/elliptic-6.5.4
-* Merge pull request [#13](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/13) from sliedig/develop
-* Merge pull request [#12](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/12) from sliedig/develop
-* Merge pull request [#11](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/11) from awslabs/dependabot/npm_and_yarn/docs/socket.io-2.4.1
-* Merge pull request [#10](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/10) from awslabs/dependabot/npm_and_yarn/docs/ini-1.3.8
-* Merge pull request [#9](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/9) from awslabs/dependabot/npm_and_yarn/docs/object-path-0.11.5
-* Merge pull request [#7](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/7) from t1agob/develop
-* Merge pull request [#8](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/8) from sliedig/develop
-* Merge pull request [#5](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/5) from sliedig/develop
-* Merge pull request [#4](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/4) from sliedig/develop
-* Merge pull request [#3](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/3) from sliedig/develop
-* Merge pull request [#2](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/2) from awslabs/dependabot/npm_and_yarn/docs/prismjs-1.21.0
-* Merge pull request [#1](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/1) from sliedig/develop
+* Merge pull request [#139](https://github.com/aws-powertools/lambda-dotnet/issues/139) from awslabs/amirkaws-resolve-conflicts-2
+* Merge pull request [#135](https://github.com/aws-powertools/lambda-dotnet/issues/135) from awslabs/amirkaws-update-versions
+* Merge pull request [#134](https://github.com/aws-powertools/lambda-dotnet/issues/134) from heitorlessa/chore/lockdown-gh-pages-workflow
+* Merge pull request [#132](https://github.com/aws-powertools/lambda-dotnet/issues/132) from heitorlessa/chore/github-concurrency-docs
+* Merge pull request [#130](https://github.com/aws-powertools/lambda-dotnet/issues/130) from heitorlessa/chore/enforce-github-actions-sha
+* Merge pull request [#128](https://github.com/aws-powertools/lambda-dotnet/issues/128) from sliedig/sliedig-ci
+* Merge pull request [#127](https://github.com/aws-powertools/lambda-dotnet/issues/127) from sliedig/sliedig-ci
+* Merge pull request [#126](https://github.com/aws-powertools/lambda-dotnet/issues/126) from sliedig/develop
+* Merge pull request [#123](https://github.com/aws-powertools/lambda-dotnet/issues/123) from sliedig/develop
+* Merge pull request [#1](https://github.com/aws-powertools/lambda-dotnet/issues/1) from sliedig/sliedig/develop
+* Merge pull request [#121](https://github.com/aws-powertools/lambda-dotnet/issues/121) from awslabs/amirkaws-update-versions
+* Merge pull request [#116](https://github.com/aws-powertools/lambda-dotnet/issues/116) from awslabs/amirkaws/add-di-support-for-logging
+* Merge pull request [#113](https://github.com/aws-powertools/lambda-dotnet/issues/113) from awslabs/amirkaws/update-doc-1
+* Merge pull request [#111](https://github.com/aws-powertools/lambda-dotnet/issues/111) from awslabs/amirkaws/add-env-vars-docs
+* Merge pull request [#102](https://github.com/aws-powertools/lambda-dotnet/issues/102) from sliedig/sliedig/examples
+* Merge pull request [#103](https://github.com/aws-powertools/lambda-dotnet/issues/103) from awslabs/amirkaws/fix-example-issues
+* Merge pull request [#97](https://github.com/aws-powertools/lambda-dotnet/issues/97) from sliedig/sliedig/examples
+* Merge pull request [#95](https://github.com/aws-powertools/lambda-dotnet/issues/95) from awslabs/pr/91
+* Merge pull request [#90](https://github.com/aws-powertools/lambda-dotnet/issues/90) from sliedig/develop
+* Merge pull request [#89](https://github.com/aws-powertools/lambda-dotnet/issues/89) from awslabs/api-docs-template
+* Merge pull request [#74](https://github.com/aws-powertools/lambda-dotnet/issues/74) from awslabs/amirkaws/disable-tracing-outside-lambda-env
+* Merge pull request [#66](https://github.com/aws-powertools/lambda-dotnet/issues/66) from sliedig/develop
+* Merge pull request [#59](https://github.com/aws-powertools/lambda-dotnet/issues/59) from sliedig/develop
+* Merge pull request [#58](https://github.com/aws-powertools/lambda-dotnet/issues/58) from sliedig/sliedig/nuget
+* Merge pull request [#32](https://github.com/aws-powertools/lambda-dotnet/issues/32) from awslabs/amirkaws/metrics-1
+* Merge pull request [#31](https://github.com/aws-powertools/lambda-dotnet/issues/31) from t1agob/develop
+* Merge pull request [#2](https://github.com/aws-powertools/lambda-dotnet/issues/2) from awslabs/develop
+* Merge pull request [#25](https://github.com/aws-powertools/lambda-dotnet/issues/25) from t1agob/develop
+* Merge pull request [#1](https://github.com/aws-powertools/lambda-dotnet/issues/1) from t1agob/sourcegenerators
+* Merge pull request [#24](https://github.com/aws-powertools/lambda-dotnet/issues/24) from sliedig/develop
+* Merge pull request [#23](https://github.com/aws-powertools/lambda-dotnet/issues/23) from sliedig/develop
+* Merge pull request [#22](https://github.com/aws-powertools/lambda-dotnet/issues/22) from sliedig/develop
+* Merge pull request [#21](https://github.com/aws-powertools/lambda-dotnet/issues/21) from t1agob/develop
+* Merge pull request [#19](https://github.com/aws-powertools/lambda-dotnet/issues/19) from awslabs/dependabot/npm_and_yarn/docs/url-parse-1.5.1
+* Merge pull request [#18](https://github.com/aws-powertools/lambda-dotnet/issues/18) from awslabs/dependabot/npm_and_yarn/docs/hosted-git-info-2.8.9
+* Merge pull request [#17](https://github.com/aws-powertools/lambda-dotnet/issues/17) from awslabs/dependabot/npm_and_yarn/docs/ua-parser-js-0.7.28
+* Merge pull request [#16](https://github.com/aws-powertools/lambda-dotnet/issues/16) from awslabs/dependabot/npm_and_yarn/docs/underscore-1.13.1
+* Merge pull request [#15](https://github.com/aws-powertools/lambda-dotnet/issues/15) from awslabs/dependabot/npm_and_yarn/docs/ssri-6.0.2
+* Merge pull request [#14](https://github.com/aws-powertools/lambda-dotnet/issues/14) from awslabs/dependabot/npm_and_yarn/docs/elliptic-6.5.4
+* Merge pull request [#13](https://github.com/aws-powertools/lambda-dotnet/issues/13) from sliedig/develop
+* Merge pull request [#12](https://github.com/aws-powertools/lambda-dotnet/issues/12) from sliedig/develop
+* Merge pull request [#11](https://github.com/aws-powertools/lambda-dotnet/issues/11) from awslabs/dependabot/npm_and_yarn/docs/socket.io-2.4.1
+* Merge pull request [#10](https://github.com/aws-powertools/lambda-dotnet/issues/10) from awslabs/dependabot/npm_and_yarn/docs/ini-1.3.8
+* Merge pull request [#9](https://github.com/aws-powertools/lambda-dotnet/issues/9) from awslabs/dependabot/npm_and_yarn/docs/object-path-0.11.5
+* Merge pull request [#7](https://github.com/aws-powertools/lambda-dotnet/issues/7) from t1agob/develop
+* Merge pull request [#8](https://github.com/aws-powertools/lambda-dotnet/issues/8) from sliedig/develop
+* Merge pull request [#5](https://github.com/aws-powertools/lambda-dotnet/issues/5) from sliedig/develop
+* Merge pull request [#4](https://github.com/aws-powertools/lambda-dotnet/issues/4) from sliedig/develop
+* Merge pull request [#3](https://github.com/aws-powertools/lambda-dotnet/issues/3) from sliedig/develop
+* Merge pull request [#2](https://github.com/aws-powertools/lambda-dotnet/issues/2) from awslabs/dependabot/npm_and_yarn/docs/prismjs-1.21.0
+* Merge pull request [#1](https://github.com/aws-powertools/lambda-dotnet/issues/1) from sliedig/develop
 
 
-[Unreleased]: https://github.com/awslabs/aws-lambda-powertools-dotnet/compare/1.3.0...HEAD
-[1.3.0]: https://github.com/awslabs/aws-lambda-powertools-dotnet/compare/1.2.0...1.3.0
-[1.2.0]: https://github.com/awslabs/aws-lambda-powertools-dotnet/compare/1.1.0...1.2.0
-[1.1.0]: https://github.com/awslabs/aws-lambda-powertools-dotnet/compare/v1.0.1...1.1.0
-[v1.0.1]: https://github.com/awslabs/aws-lambda-powertools-dotnet/compare/v1.0.0...v1.0.1
-[v1.0.0]: https://github.com/awslabs/aws-lambda-powertools-dotnet/compare/v0.0.2-preview...v1.0.0
-[v0.0.2-preview]: https://github.com/awslabs/aws-lambda-powertools-dotnet/compare/v0.0.1-preview.1...v0.0.2-preview
+[Unreleased]: https://github.com/aws-powertools/lambda-dotnet/compare/1.3.0...HEAD
+[1.3.0]: https://github.com/aws-powertools/lambda-dotnet/compare/1.2.0...1.3.0
+[1.2.0]: https://github.com/aws-powertools/lambda-dotnet/compare/1.1.0...1.2.0
+[1.1.0]: https://github.com/aws-powertools/lambda-dotnet/compare/v1.0.1...1.1.0
+[v1.0.1]: https://github.com/aws-powertools/lambda-dotnet/compare/v1.0.0...v1.0.1
+[v1.0.0]: https://github.com/aws-powertools/lambda-dotnet/compare/v0.0.2-preview...v1.0.0
+[v0.0.2-preview]: https://github.com/aws-powertools/lambda-dotnet/compare/v0.0.1-preview.1...v0.0.2-preview

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -120,7 +120,7 @@ Manage [labels](#labels), review issues regularly, and create new labels as need
 
 > TODO: This is an area we want to automate using the new GitHub GraphQL API.
 
-Make sure issues are assigned to our [board of activities](https://github.com/orgs/awslabs/projects/51/) and have the right [status](https://awslabs.github.io/aws-lambda-powertools-dotnet/latest/roadmap/#roadmap-status-definition).
+Make sure issues are assigned to our [board of activities](https://github.com/orgs/awslabs/projects/51/) and have the right [status](https://docs.powertools.aws.dev/lambda-dotnet/latest/roadmap/#roadmap-status-definition).
 
 Use our [labels](#labels) to signal good first issues to new community members, and to set expectation that this might need additional feedback from the author, other customers, experienced community members and/or maintainers.
 
@@ -152,7 +152,7 @@ Keep the `develop` branch at production quality at all times. Backport features 
 
 ### Manage Roadmap
 
-See [Roadmap section](https://awslabs.github.io/aws-lambda-powertools-dotnet/roadmap/)
+See [Roadmap section](https://docs.powertools.aws.dev/lambda-dotnet/roadmap/)
 
 Ensure the repo highlights features that should be elevated to the project roadmap. Be clear about the feature’s status, priority, target version, and whether or not it should be elevated to the roadmap.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -106,7 +106,7 @@ Review pull requests regularly, comment, suggest, reject, merge and close. Accep
 
 PRs are [labeled](#labels) based on file changes and semantic title. Pay attention to whether labels reflect the current state of the PR and correct accordingly.
 
-Use and enforce [semantic versioning](https://semver.org/) pull request titles, as these will be used for [CHANGELOG](CHANGELOG.md) and [Release notes](https://github.com/awslabs/aws-lambda-powertools-dotnet/releases) - make sure they communicate their intent at the human level.
+Use and enforce [semantic versioning](https://semver.org/) pull request titles, as these will be used for [CHANGELOG](CHANGELOG.md) and [Release notes](https://github.com/aws-powertools/lambda-dotnet/releases) - make sure they communicate their intent at the human level.
 
 > TODO: This is an area we want to automate using the new GitHub GraphQL API.
 
@@ -182,7 +182,7 @@ When in doubt, use `need-more-information` or `need-customer-feedback` labels to
 
 ### Crediting contributions
 
-We credit all contributions as part of each [release note](https://github.com/awslabs/aws-lambda-powertools-dotnet/releases) as an automated process. If you find contributors are missing from the release note you're producing, please add them manually.
+We credit all contributions as part of each [release note](https://github.com/aws-powertools/lambda-dotnet/releases) as an automated process. If you find contributors are missing from the release note you're producing, please add them manually.
 
 ### Is that a bug?
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Build](https://github.com/aws-powertools/lambda-dotnet/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/aws-powertools/lambda-dotnet/actions/workflows/build.yml)
 [![Join our Discord](https://dcbadge.vercel.app/api/server/B8zZKbbyET)](https://discord.gg/B8zZKbbyET)
 
-Powertools is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://awslabs.github.io/aws-lambda-powertools-dotnet/#features).
+Powertools is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://docs.powertools.aws.dev/lambda-dotnet/#features).
 
-**[📜 Documentation](https://awslabs.github.io/aws-lambda-powertools-dotnet/)** | **[NuGet](https://www.nuget.org/)** | **[Roadmap](https://github.com/awslabs/aws-lambda-powertools-roadmap/projects/1)** | **[Examples](#examples)**
+**[📜 Documentation](https://docs.powertools.aws.dev/lambda-dotnet/)** | **[NuGet](https://www.nuget.org/)** | **[Roadmap](https://github.com/awslabs/aws-lambda-powertools-roadmap/projects/1)** | **[Examples](#examples)**
 
 > **Join us on the AWS Developers Slack at `#lambda-powertools`** - **[Invite, if you don't have an account](https://join.slack.com/t/awsdevelopers/shared_invite/zt-gu30gquv-EhwIYq3kHhhysaZ2aIX7ew)**
 
@@ -14,13 +14,13 @@ Powertools is a developer toolkit to implement Serverless [best practices and in
 
 Lambda Powertools provides three core utilities:
 
-* **[Logging](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/)** - provides a custom logger class that outputs structured JSON. It allows you to pass in strings or more complex objects, and will take care of serializing the log output. Common use cases—such as logging the Lambda event payload and capturing cold start information—are handled for you, including appending custom keys to the logger at anytime.
+* **[Logging](https://docs.powertools.aws.dev/lambda-dotnet/core/logging/)** - provides a custom logger class that outputs structured JSON. It allows you to pass in strings or more complex objects, and will take care of serializing the log output. Common use cases—such as logging the Lambda event payload and capturing cold start information—are handled for you, including appending custom keys to the logger at anytime.
 
-* **[Metrics](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/)** - makes collecting custom metrics from your application simple, without the need to make synchronous requests to external systems. This functionality is powered by [Amazon CloudWatch Embedded Metric Format (EMF)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format.html), which allows for capturing metrics asynchronously.
+* **[Metrics](https://docs.powertools.aws.dev/lambda-dotnet/core/metrics/)** - makes collecting custom metrics from your application simple, without the need to make synchronous requests to external systems. This functionality is powered by [Amazon CloudWatch Embedded Metric Format (EMF)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format.html), which allows for capturing metrics asynchronously.
 
-* **[Tracing](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/)** - provides a simple way to send traces from functions to AWS X-Ray to provide visibility into function calls, interactions with other AWS services, or external HTTP requests. Annotations can easily be added to traces to allow filtering traces based on key information. For example, when using Tracer, a ColdStart annotation is created for you so you can easily group and analyze traces where there was an initialization overhead.
+* **[Tracing](https://docs.powertools.aws.dev/lambda-dotnet/core/tracing/)** - provides a simple way to send traces from functions to AWS X-Ray to provide visibility into function calls, interactions with other AWS services, or external HTTP requests. Annotations can easily be added to traces to allow filtering traces based on key information. For example, when using Tracer, a ColdStart annotation is created for you so you can easily group and analyze traces where there was an initialization overhead.
 
-* **[Parameters (developer preview)](https://awslabs.github.io/aws-lambda-powertools-dotnet/core/parameters/)** - provides high-level functionality to retrieve one or multiple parameter values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html){target="_blank"}, [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/){target="_blank"}, or [Amazon DynamoDB](https://aws.amazon.com/dynamodb/){target="_blank"}. We also provide extensibility to bring your own providers.
+* **[Parameters (developer preview)](https://docs.powertools.aws.dev/lambda-dotnet/core/parameters/)** - provides high-level functionality to retrieve one or multiple parameter values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html){target="_blank"}, [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/){target="_blank"}, or [Amazon DynamoDB](https://aws.amazon.com/dynamodb/){target="_blank"}. We also provide extensibility to bring your own providers.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AWS Lambda Powertools for .NET
 
 ![aws provider](https://img.shields.io/badge/provider-AWS-orange?logo=amazon-aws&color=ff9900)
-[![Build](https://github.com/awslabs/aws-lambda-powertools-dotnet/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/awslabs/aws-lambda-powertools-dotnet/actions/workflows/build.yml)
+[![Build](https://github.com/aws-powertools/lambda-dotnet/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/aws-powertools/lambda-dotnet/actions/workflows/build.yml)
 [![Join our Discord](https://dcbadge.vercel.app/api/server/B8zZKbbyET)](https://discord.gg/B8zZKbbyET)
 
 Powertools is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://awslabs.github.io/aws-lambda-powertools-dotnet/#features).
@@ -67,7 +67,7 @@ Not using .NET? No problem, we have you covered. Here are the other members of t
 
 We welcome contributions from developers of all levels to our open-source project on GitHub. If you'd like to contribute, please check our contributing guidelines and help make this project more accessible.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=awslabs/aws-lambda-powertools-dotnet&type=Date)](https://star-history.com/#awslabs/aws-lambda-powertools-dotnet&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=aws-powertools/lambda-dotnet&type=Date)](https://star-history.com/#aws-powertools/lambda-dotnet&Date)
 
 ## Connect
 

--- a/apidocs/index.md
+++ b/apidocs/index.md
@@ -11,4 +11,4 @@ To get started use the `API Documentaion` menu on the navigation bar, or search 
 
 ## Feedback
 
-If you have any feedback, create a new issue in the *AWS Lambda Powertools for .NET* repository on [GitHub](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues).
+If you have any feedback, create a new issue in the *AWS Lambda Powertools for .NET* repository on [GitHub](https://github.com/aws-powertools/lambda-dotnet/issues).

--- a/apidocs/index.md
+++ b/apidocs/index.md
@@ -7,7 +7,7 @@ To get started use the `API Documentaion` menu on the navigation bar, or search 
 > [!NOTE]
 > Are you looking for documentation on how to use AWS Lambda Powertools for .NET utilities and code samples?
 >  
-> 👉 [Here](https://awslabs.github.io/aws-lambda-powertools-dotnet/) is the perfect place to start.
+> 👉 [Here](https://docs.powertools.aws.dev/lambda-dotnet/) is the perfect place to start.
 
 ## Feedback
 

--- a/apidocs/toc.yml
+++ b/apidocs/toc.yml
@@ -2,4 +2,4 @@
   href: api/
   homepage: api/index.md
 - name: AWS Lambda Powertools for .NET Documentation
-  href: "https://awslabs.github.io/aws-lambda-powertools-dotnet/"
+  href: "https://docs.powertools.aws.dev/lambda-dotnet/"

--- a/apidocs/toc.yml
+++ b/apidocs/toc.yml
@@ -2,4 +2,4 @@
   href: api/
   homepage: api/index.md
 - name: Powertools for AWS Lambda (.NET) Documentation
-  href: "https://awslabs.github.io/aws-lambda-powertools-dotnet/"
+  href: "https://docs.powertools.aws.dev/lambda-dotnet/"

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -259,7 +259,7 @@ During metrics validation, if no metrics are provided then a warning will be log
     * Namespace is set
     * Metric units must be [supported by CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
 
-!!! info "We do not emit 0 as a value for ColdStart metric for cost reasons. [Let us know](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/new?assignees=&labels=feature-request%2Ctriage&template=feature_request.yml&title=Feature+request%3A+TITLE) if you'd prefer a flag to override it"
+!!! info "We do not emit 0 as a value for ColdStart metric for cost reasons. [Let us know](https://github.com/aws-powertools/lambda-dotnet/issues/new?assignees=&labels=feature-request%2Ctriage&template=feature_request.yml&title=Feature+request%3A+TITLE) if you'd prefer a flag to override it"
 
 #### Raising SchemaValidationException on empty metrics
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,9 @@ AWS Lambda Powertools for .NET (which from here will be referred as Powertools) 
 
     You can choose to support us in three ways:
 
-    1) [**Become a reference customers**](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/new?assignees=&labels=customer-reference&template=support_powertools.yml&title=%5BSupport+Lambda+Powertools%5D%3A+%3Cyour+organization+name%3E). This gives us permission to list your company in our documentation.
+    1) [**Become a reference customers**](https://github.com/aws-powertools/lambda-dotnet/issues/new?assignees=&labels=customer-reference&template=support_powertools.yml&title=%5BSupport+Lambda+Powertools%5D%3A+%3Cyour+organization+name%3E). This gives us permission to list your company in our documentation.
 
-    2) [**Share your work**](https://github.com/awslabs/aws-lambda-powertools-dotnet/issues/new?assignees=&labels=community-content&template=share_your_work.yml&title=%5BI+Made+This%5D%3A+%3CTITLE%3E). Blog posts, video, sample projects you used Powertools!
+    2) [**Share your work**](https://github.com/aws-powertools/lambda-dotnet/issues/new?assignees=&labels=community-content&template=share_your_work.yml&title=%5BI+Made+This%5D%3A+%3CTITLE%3E). Blog posts, video, sample projects you used Powertools!
 
 ## Features
 
@@ -64,9 +64,9 @@ To use the SAM CLI, you need the following tools.
 
 We have provided a few examples that should you how to use the each of the core Powertools features.
 
-* [Tracing](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/Tracing){target="_blank"} example
-* [Logging](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/Logging/){target="_blank"} example
-* [Metrics](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/main/examples/Metrics/){target="_blank"} example
+* [Tracing](https://github.com/aws-powertools/lambda-dotnet/tree/main/examples/Tracing){target="_blank"} example
+* [Logging](https://github.com/aws-powertools/lambda-dotnet/tree/main/examples/Logging/){target="_blank"} example
+* [Metrics](https://github.com/aws-powertools/lambda-dotnet/tree/main/examples/Metrics/){target="_blank"} example
 
 ## Connect
 

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -4,7 +4,7 @@ description: Utility
 ---
 
 ???+ warning
-	**This utility is currently in developer preview** and is intended strictly for feedback and testing purposes **and not for production workloads**. The version and all future versions tagged with the `-preview` suffix should be treated as not stable. Until this utility is [General Availability](https://github.com/awslabs/aws-lambda-powertools-dotnet/milestone/2) we may introduce significant breaking changes and improvements in response to customers feedback.
+	**This utility is currently in developer preview** and is intended strictly for feedback and testing purposes **and not for production workloads**. The version and all future versions tagged with the `-preview` suffix should be treated as not stable. Until this utility is [General Availability](https://github.com/aws-powertools/lambda-dotnet/milestone/2) we may introduce significant breaking changes and improvements in response to customers feedback.
 
 <!-- markdownlint-disable MD013 -->
 The Parameters utility provides high-level functionality to retrieve one or multiple parameter values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html){target="_blank"}, [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/){target="_blank"}, or [Amazon DynamoDB](https://aws.amazon.com/dynamodb/){target="_blank"}. We also provide extensibility to bring your own providers.

--- a/libraries/src/AWS.Lambda.Powertools.Common/AWS.Lambda.Powertools.Common.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Common/AWS.Lambda.Powertools.Common.csproj
@@ -10,7 +10,7 @@
       <Title>AWS Lambda Powertools for .NET</Title>
       <Description>AWS Lambda Powertools for .NET - Core package.</Description>
       <Copyright>Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
-      <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
+      <RepositoryUrl>https://github.com/aws-powertools/lambda-dotnet</RepositoryUrl>
       <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
       <PackageTags>AWS;Amazon;Lambda;Powertools</PackageTags>
       <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/AWS.Lambda.Powertools.Logging.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/AWS.Lambda.Powertools.Logging.csproj
@@ -10,7 +10,7 @@
         <Title>AWS Lambda Powertools for .NET</Title>
         <Description>AWS Lambda Powertools for .NET - Logging package.</Description>
         <Copyright>Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
-        <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
+        <RepositoryUrl>https://github.com/aws-powertools/lambda-dotnet</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageTags>AWS;Amazon;Lambda;Powertools</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/libraries/src/AWS.Lambda.Powertools.Logging/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/README.md
@@ -13,7 +13,7 @@ The logging utility provides a [AWS Lambda](https://aws.amazon.com/lambda/) opti
 
 For a full list of features go to [awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/](awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/)
 
-GitHub: https://github.com/awslabs/aws-lambda-powertools-dotnet/
+GitHub: https://github.com/aws-powertools/lambda-dotnet/
 
 ## Sample Function
 

--- a/libraries/src/AWS.Lambda.Powertools.Logging/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/README.md
@@ -11,7 +11,7 @@ The logging utility provides a [AWS Lambda](https://aws.amazon.com/lambda/) opti
 
 ## Read the docs
 
-For a full list of features go to [awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/](awslabs.github.io/aws-lambda-powertools-dotnet/core/logging/)
+For a full list of features go to [docs.powertools.aws.dev/lambda-dotnet/core/logging/](docs.powertools.aws.dev/lambda-dotnet/core/logging/)
 
 GitHub: https://github.com/aws-powertools/lambda-dotnet/
 

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/AWS.Lambda.Powertools.Metrics.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/AWS.Lambda.Powertools.Metrics.csproj
@@ -9,7 +9,7 @@
         <Title>AWS Lambda Powertools for .NET</Title>
         <Description>AWS Lambda Powertools for .NET - Metrics package.</Description>
         <Copyright>Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
-        <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
+        <RepositoryUrl>https://github.com/aws-powertools/lambda-dotnet</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageTags>AWS;Amazon;Lambda;Powertools</PackageTags>
         <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
@@ -15,11 +15,11 @@ These metrics can be visualized through [Amazon CloudWatch Console](https://aws.
 
 For a full list of features go to [awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/](awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/)
 
-GitHub: https://github.com/awslabs/aws-lambda-powertools-dotnet/
+GitHub: https://github.com/aws-powertools/lambda-dotnet/
 
 ## Sample Function
 
-View the full example here: [https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/develop/examples/Metrics](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/develop/examples/Metrics)
+View the full example here: [https://github.com/aws-powertools/lambda-dotnet/tree/develop/examples/Metrics](https://github.com/aws-powertools/lambda-dotnet/tree/develop/examples/Metrics)
 
 ```csharp
 public class Function

--- a/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Metrics/README.md
@@ -13,7 +13,7 @@ These metrics can be visualized through [Amazon CloudWatch Console](https://aws.
 
 ## Read the docs
 
-For a full list of features go to [awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/](awslabs.github.io/aws-lambda-powertools-dotnet/core/metrics/)
+For a full list of features go to [docs.powertools.aws.dev/lambda-dotnet/core/metrics/](docs.powertools.aws.dev/lambda-dotnet/core/metrics/)
 
 GitHub: https://github.com/aws-powertools/lambda-dotnet/
 

--- a/libraries/src/AWS.Lambda.Powertools.Parameters/AWS.Lambda.Powertools.Parameters.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Parameters/AWS.Lambda.Powertools.Parameters.csproj
@@ -12,7 +12,7 @@
         <Title>AWS Lambda Powertools for .NET</Title>
         <Description>AWS Lambda Powertools for .NET - Parameters package.</Description>
         <Copyright>Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
-        <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
+        <RepositoryUrl>https://github.com/aws-powertools/lambda-dotnet</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageTags>AWS;Amazon;Lambda;Powertools</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/libraries/src/AWS.Lambda.Powertools.Parameters/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Parameters/README.md
@@ -13,7 +13,7 @@ The Parameters utility provides high-level functionality to retrieve one or mult
 
 For a full list of features go to [awslabs.github.io/aws-lambda-powertools-dotnet/utilities/parameters/](awslabs.github.io/aws-lambda-powertools-dotnet/utilities/parameters/)
 
-GitHub: <https://github.com/awslabs/aws-lambda-powertools-dotnet/>
+GitHub: <https://github.com/aws-powertools/lambda-dotnet/>
 
 ## Sample Function using AWS Systems Manager Parameter Store
 

--- a/libraries/src/AWS.Lambda.Powertools.Parameters/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Parameters/README.md
@@ -11,7 +11,7 @@ The Parameters utility provides high-level functionality to retrieve one or mult
 
 ## Read the docs
 
-For a full list of features go to [awslabs.github.io/aws-lambda-powertools-dotnet/utilities/parameters/](awslabs.github.io/aws-lambda-powertools-dotnet/utilities/parameters/)
+For a full list of features go to [docs.powertools.aws.dev/lambda-dotnet/utilities/parameters/](docs.powertools.aws.dev/lambda-dotnet/utilities/parameters/)
 
 GitHub: <https://github.com/aws-powertools/lambda-dotnet/>
 

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/AWS.Lambda.Powertools.Tracing.csproj
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/AWS.Lambda.Powertools.Tracing.csproj
@@ -10,7 +10,7 @@
         <Title>AWS Lambda Powertools for .NET</Title>
         <Description>AWS Lambda Powertools for .NET - Tracing package.</Description>
         <Copyright>Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
-        <RepositoryUrl>https://github.com/awslabs/aws-lambda-powertools-dotnet</RepositoryUrl>
+        <RepositoryUrl>https://github.com/aws-powertools/lambda-dotnet</RepositoryUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageTags>AWS;Amazon;Lambda;Powertools</PackageTags>
         <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
@@ -15,11 +15,11 @@ a provides functionality to reduce the overhead of performing common tracing tas
 
 For a full list of features go to [awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/](awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/)
 
-**GitHub:** https://github.com/awslabs/aws-lambda-powertools-dotnet/
+**GitHub:** https://github.com/aws-powertools/lambda-dotnet/
 
 ## Sample Function
 
-View the full example here: [https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/develop/examples/Tracing](https://github.com/awslabs/aws-lambda-powertools-dotnet/tree/develop/examples/Tracing)
+View the full example here: [https://github.com/aws-powertools/lambda-dotnet/tree/develop/examples/Tracing](https://github.com/aws-powertools/lambda-dotnet/tree/develop/examples/Tracing)
 
 ```csharp
 public class Function

--- a/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
+++ b/libraries/src/AWS.Lambda.Powertools.Tracing/README.md
@@ -13,7 +13,7 @@ a provides functionality to reduce the overhead of performing common tracing tas
 
 ## Read the docs
 
-For a full list of features go to [awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/](awslabs.github.io/aws-lambda-powertools-dotnet/core/tracing/)
+For a full list of features go to [docs.powertools.aws.dev/lambda-dotnet/core/tracing/](docs.powertools.aws.dev/lambda-dotnet/core/tracing/)
 
 **GitHub:** https://github.com/aws-powertools/lambda-dotnet/
 
@@ -129,4 +129,4 @@ public class Function
 
 ## Sample output
 
-![Tracing showcase](http://awslabs.github.io/aws-lambda-powertools-dotnet/media/tracer_utility_showcase.png)
+![Tracing showcase](http://docs.powertools.aws.dev/lambda-dotnet/media/tracer_utility_showcase.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Lambda Powertools .NET
 site_description: AWS Lambda Powertools for .NET
 site_author: Amazon Web Services
-repo_url: https://github.com/awslabs/aws-lambda-powertools-dotnet
+repo_url: https://github.com/aws-powertools/lambda-dotnet
 edit_uri: edit/develop/docs
 
 nav:


### PR DESCRIPTION
> **Warning**
> Do not merge until after the move.

> Please provide the issue number

Issue number: #282 

## Summary

### Changes

> Please provide a summary of what's being changed

Performed a find & replace for `awslabs/aws-lambda-powertools-dotnet` to `aws-powertools/lambda-dotnet`

### User experience

> Please share what the user experience looks like before and after this change

Users will be redirected from the current URL to the new URL (https://github.com/aws-powertools/lambda-dotnet).

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [X] [Meets tenets criteria](https://awslabs.github.io/aws-lambda-powertools-dotnet/tenets)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented
* [X] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
